### PR TITLE
サイト名表記とハンドルネームを修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,13 +3,17 @@ import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import react from "@astrojs/react";
 import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
-
 import sitemap from "@astrojs/sitemap";
+import { CONSTS } from "./consts";
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [tailwind(), react(), sitemap()],
-	site: "https://naary.me",
+	integrations: [
+		tailwind(),
+		react(),
+		sitemap(),
+	],
+	site: CONSTS.SITE_DOMAIN,
 	vite: {
 		plugins: [vanillaExtractPlugin()],
 	},

--- a/consts.ts
+++ b/consts.ts
@@ -1,0 +1,7 @@
+export const CONSTS = {
+	SITE_NAME: "PORTFOLIO",
+	SITE_DOMAIN: import.meta.env.DEV
+		? "http://localhost:4321/"
+		: `https://${import.meta.env.VERCEL_URL}`,
+	SITE_DESCRIPTION: "Personal website of oonawa",
+} as const;

--- a/public/manifest.webmanifest.txt
+++ b/public/manifest.webmanifest.txt
@@ -1,6 +1,6 @@
 {
-  "name": "NAARY.ME | Personal website of naary",
-  "short_name": "NAARY.ME",
+  "name": "PORTFOLIO | Personal website of oonawa",
+  "short_name": "PORTFOLIO",
   "icons": [
     { "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
 

--- a/src/components/Layouts/Footer/index.tsx
+++ b/src/components/Layouts/Footer/index.tsx
@@ -2,7 +2,7 @@ export default function Footer() {
 	return (
 		<footer className="py-20 sm:py-40 font-sans font-bold">
 			<div className="text-text-darken-2 flex flex-col text-center">
-				<span>2024 naary</span>
+				<span>2024 oonawa</span>
 				<div className="flex justify-center gap-2">
 					<a href="/privacy">Privacy</a>
 					<span>|</span>

--- a/src/components/Layouts/Header/index.tsx
+++ b/src/components/Layouts/Header/index.tsx
@@ -1,5 +1,6 @@
 import HeaderText from "./Text";
 import HeaderTextContainer from "./Text/Container";
+import { CONSTS } from "../../../../consts";
 
 type Props = {
 	isTopPage?: boolean;
@@ -20,7 +21,7 @@ export default function Header({ isTopPage = false, title }: Props) {
 					) : (
 						<HeaderTextContainer>
 							<a href="/">
-								<HeaderText>NAARY.ME /</HeaderText>
+								<HeaderText>{CONSTS.SITE_NAME} /</HeaderText>
 							</a>
 						</HeaderTextContainer>
 					)}

--- a/src/components/Layouts/Meta.tsx
+++ b/src/components/Layouts/Meta.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import "../../styles/font.css";
 import "../../styles/animation.css";
 import "../../styles/global.css";
+import { CONSTS } from "../../../consts";
 
 export type SiteOg = {
 	description: string;
@@ -15,8 +16,6 @@ type Props = {
 	og: SiteOg;
 	children: React.ReactNode;
 };
-
-const SITE_NAME = "NAARY.ME";
 
 export default function Meta({ title, og, children }: Props) {
 	return (
@@ -46,21 +45,30 @@ export default function Meta({ title, og, children }: Props) {
 				<meta name="description" content={og.description} />
 				<meta
 					property="og:url"
-					content={og.url ? `https://naary.me/${og.url}` : "https://naary.me"}
+					content={
+						og.url
+							? `https://${CONSTS.SITE_DOMAIN}/${og.url}`
+							: CONSTS.SITE_DOMAIN
+					}
 				/>
 				<meta property="og:type" content={og.type} />
 				<meta property="og:description" content={og.description} />
-				<meta property="og:title" content={title ? `${title} | ${SITE_NAME}` : SITE_NAME} />
 				<meta
-					property="og:image"
-					content={og.image ? og.image : "/og.png"}
+					property="og:title"
+					content={title ? `${title} | ${CONSTS.SITE_NAME}` : CONSTS.SITE_NAME}
 				/>
-				<meta property="og:site_name" content={SITE_NAME} />
+				<meta property="og:image" content={og.image ? og.image : "/og.png"} />
+				<meta property="og:site_name" content={CONSTS.SITE_NAME} />
 				<meta name="twitter:card" content="summary" />
-				<meta name="twitter:title" content={title ? `${title} | ${SITE_NAME}` : SITE_NAME} />
+				<meta
+					name="twitter:title"
+					content={title ? `${title} | ${CONSTS.SITE_NAME}` : CONSTS.SITE_NAME}
+				/>
 				<meta name="twitter:description" content={og.description} />
 				<meta name="twitter:image" content="/og.png" />
-				<title>{title ? `${title} | ${SITE_NAME}` : SITE_NAME}</title>
+				<title>
+					{title ? `${title} | ${CONSTS.SITE_NAME}` : CONSTS.SITE_NAME}
+				</title>
 			</head>
 			<body className="bg-background-default m-0 text-text-default font-sans">
 				{children}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,11 @@
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+	readonly API_SERVICE_DOMAIN: string;
+	readonly API_KEY: string;
+	readonly VERCEL_URL: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}

--- a/src/lib/cms-client/index.ts
+++ b/src/lib/cms-client/index.ts
@@ -6,17 +6,20 @@ import type {
 	MicroCMSContentId,
 } from "microcms-js-sdk";
 
-if (!process.env.API_SERVICE_DOMAIN) {
+const serviceDomain = import.meta.env.API_SERVICE_DOMAIN;
+const apiKey = import.meta.env.API_KEY;
+
+if (!serviceDomain) {
 	throw new Error("microCMSのサービスドメインが設定されていません。");
 }
 
-if (!process.env.API_KEY) {
+if (!serviceDomain) {
 	throw new Error("microCMSのAPIキーが設定されていません。");
 }
 
 export const client = createClient({
-	serviceDomain: process.env.API_SERVICE_DOMAIN,
-	apiKey: process.env.API_KEY,
+	serviceDomain,
+	apiKey,
 });
 
 export type Blog = {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,14 +7,15 @@ import { getAboutContent } from "../lib/cms-client";
 import { getDate } from "../lib/day-js";
 import { parseHtml } from "../lib/html-parser";
 import type { SiteOg } from "../components/Layouts/Meta";
+import { CONSTS } from "../../consts";
 
 const about = await getAboutContent();
 const age = about.birth_year ? getDate().year() - about.birth_year : null;
 
 const og: SiteOg = {
-	description: "about NAARY.ME",
+	description: `about ${CONSTS.SITE_NAME}`,
 	type: "article",
-	url: "about"
+	url: "about",
 };
 ---
 

--- a/src/pages/blogs.astro
+++ b/src/pages/blogs.astro
@@ -6,13 +6,14 @@ import Empty from "../components/Routes/Blogs/Empty";
 import ListItem from "../components/Routes/Blogs/ListItem";
 import { getBlogList } from "../lib/cms-client";
 import type { SiteOg } from "../components/Layouts/Meta";
+import { CONSTS } from "../../consts";
 
 const blogs = await getBlogList();
 
 const og: SiteOg = {
-	description: "NAARY.ME's blog entries",
+	description: `${CONSTS.SITE_NAME}'s blog entries`,
 	type: "website",
-	url: "blogs"
+	url: "blogs",
 };
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,17 +11,18 @@ import ThridLineContainer from "../components/Routes/Top/Menu/ThridLine/Containe
 import IconContainer from "../components/Routes/Top/Menu/ThridLine/Icon/Container";
 import { getTopMenuImages } from "../lib/cms-client";
 import type { SiteOg } from "../components/Layouts/Meta";
+import { CONSTS } from "../../consts";
 
 const { blog, about, experiences, socials } = await getTopMenuImages();
 
 const og: SiteOg = {
-	description: "Personal website of naary",
+	description: CONSTS.SITE_DESCRIPTION,
 	type: "website",
 };
 ---
 
 <Meta og={og}>
-	<Header isTopPage={true} title="NAARY.ME" />
+	<Header isTopPage={true} title={CONSTS.SITE_NAME} />
 	<main class="secondIn">
 		<GridContainer>
 			<FirstLineContainer>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -5,9 +5,10 @@ import Footer from "../components/Layouts/Footer";
 import ArticleContainer from "../components/Routes/Blog/Article";
 import "../styles/blog/html-content.css";
 import type { SiteOg } from "../components/Layouts/Meta";
+import { CONSTS } from "../../consts";
 
 const og: SiteOg = {
-	description: "NAARY.ME's privacy policy",
+	description: `${CONSTS.SITE_NAME}'s privacy policy`,
 	type: "article",
 	url: "privacy",
 };
@@ -18,9 +19,11 @@ const og: SiteOg = {
 	<main class="secondIn">
 		<ArticleContainer>
 			<section class="pt-40">
-				<h2 class="heading-2">NAARY.MEにおけるプライバシー</h2>
+				<h2 class="heading-2">{`${CONSTS.SITE_NAME}におけるプライバシー`}</h2>
 				<p class="paragraph">
-					NAARY.ME（以下、当ウェブサイト）では、広告の配信やアクセス解析は行われず、特定を目的とした個人情報を収集することはありません。
+					{
+						`${CONSTS.SITE_NAME}（以下、当ウェブサイト）では、広告の配信やアクセス解析は行われず、特定を目的とした個人情報を収集することはありません。`
+					}
 				</p>
 
 				<h3 class="heading-3">IPアドレス、Cookie等の収集</h3>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,14 +1,15 @@
 import rss from "@astrojs/rss";
 import { getBlogList } from "../lib/cms-client";
 import type { APIContext } from "astro";
+import { CONSTS } from "../../consts";
 
 export async function GET(context: APIContext) {
 	const blogs = await getBlogList();
 
 	return rss({
-		title: "NAARY.ME",
-		description: "Personal website of naary",
-		site: context.site?.origin ?? "https://naary.me",
+		title: CONSTS.SITE_NAME,
+		description: CONSTS.SITE_DESCRIPTION,
+		site: context.site?.origin ?? CONSTS.SITE_DOMAIN,
 		items: blogs.map((blog) => ({
 			title: blog.title,
 			description: blog.summary,


### PR DESCRIPTION
## 概要
サイト名（閉鎖前の独自ドメインまま）をいったん「PORTFOLIO」へ修正


## 変更内容

- fix: 環境変数の読み込み方法（`process.env` → `import.meta.env`）
- feat: Vercelのシステム環境変数を読み込み（今回はドメインを取得しない）
- feat: サイト全体で用いる情報を定数化
- fix: ベタ書きを定数と差し替え
- fix: webmaniefst（生成を自動化するインテグレーションを入れてみたが動かなかったので手動で修正）