### PR TITLE
ExperienceのRSSタイムラインの初期表示を高速化

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@astrojs/vercel": "^9.0.4",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",
+		"@upstash/redis": "^1.36.1",
 		"astro": "^5.16.15",
 		"cheerio": "^1.0.0",
 		"dayjs": "^1.11.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,19 +22,22 @@ importers:
         version: 3.7.0
       '@astrojs/tailwind':
         specifier: ^6.0.2
-        version: 6.0.2(astro@5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+        version: 6.0.2(astro@5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
       '@astrojs/vercel':
         specifier: ^9.0.4
-        version: 9.0.4(astro@5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(react@18.3.1)(rollup@4.56.0)
+        version: 9.0.4(astro@5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(react@18.3.1)(rollup@4.56.0)
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.18
       '@types/react-dom':
         specifier: ^18.3.5
         version: 18.3.5(@types/react@18.3.18)
+      '@upstash/redis':
+        specifier: ^1.36.1
+        version: 1.36.1
       astro:
         specifier: ^5.16.15
-        version: 5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1)
+        version: 5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1)
       cheerio:
         specifier: ^1.0.0
         version: 1.0.0
@@ -929,6 +932,9 @@ packages:
 
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
+
+  '@upstash/redis@1.36.1':
+    resolution: {integrity: sha512-N6SjDcgXdOcTAF+7uNoY69o7hCspe9BcA7YjQdxVu5d25avljTwyLaHBW3krWjrP0FfocgMk94qyVtQbeDp39A==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -2975,9 +2981,9 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/tailwind@6.0.2(astro@5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))':
+  '@astrojs/tailwind@6.0.2(astro@5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)))(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))':
     dependencies:
-      astro: 5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1)
+      astro: 5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1)
       autoprefixer: 10.4.23(postcss@8.5.6)
       postcss: 8.5.6
       postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
@@ -2997,14 +3003,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vercel@9.0.4(astro@5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(react@18.3.1)(rollup@4.56.0)':
+  '@astrojs/vercel@9.0.4(astro@5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1))(react@18.3.1)(rollup@4.56.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.5
       '@vercel/analytics': 1.6.1(react@18.3.1)
       '@vercel/functions': 2.2.13
       '@vercel/nft': 0.30.4(rollup@4.56.0)
       '@vercel/routing-utils': 5.3.2
-      astro: 5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1)
+      astro: 5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1)
       esbuild: 0.25.12
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -3689,6 +3695,10 @@ snapshots:
 
   '@ungap/structured-clone@1.2.1': {}
 
+  '@upstash/redis@1.36.1':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@vercel/analytics@1.6.1(react@18.3.1)':
     optionalDependencies:
       react: 18.3.1
@@ -3858,7 +3868,7 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
-  astro@5.16.15(@types/node@22.10.2)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1):
+  astro@5.16.15(@types/node@22.10.2)(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)(jiti@2.4.2)(rollup@4.56.0)(typescript@5.7.2)(yaml@2.7.1):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.5
@@ -3913,7 +3923,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.3
       unist-util-visit: 5.0.0
-      unstorage: 1.17.4(@vercel/functions@2.2.13)
+      unstorage: 1.17.4(@upstash/redis@1.36.1)(@vercel/functions@2.2.13)
       vfile: 6.0.3
       vite: 6.4.1(@types/node@22.10.2)(jiti@2.4.2)(yaml@2.7.1)
       vitefu: 1.1.1(vite@6.4.1(@types/node@22.10.2)(jiti@2.4.2)(yaml@2.7.1))
@@ -5698,7 +5708,7 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  unstorage@1.17.4(@vercel/functions@2.2.13):
+  unstorage@1.17.4(@upstash/redis@1.36.1)(@vercel/functions@2.2.13):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -5709,6 +5719,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
     optionalDependencies:
+      '@upstash/redis': 1.36.1
       '@vercel/functions': 2.2.13
 
   update-browserslist-db@1.1.1(browserslist@4.24.3):

--- a/src/components/Routes/Experiences/Container/index.astro
+++ b/src/components/Routes/Experiences/Container/index.astro
@@ -5,13 +5,56 @@ import FeedYear from "../FeedYear";
 import FeedMonth from "../FeedMonth";
 import { getAboutContent, getTopMenuImages } from "../../../../lib/cms-client";
 import { getRssTimeline, groupItems } from "../../../../lib/rss-reader";
+import type { GroupedPerYear } from "../../../../lib/rss-reader";
+import type { SocialIcon } from "../../../../lib/cms-client";
+import { redis } from "../../../../lib/kv-client";
 
-const about = await getAboutContent();
-const feedItemList = await getRssTimeline(about.rss);
-const { socials } = await getTopMenuImages();
+const CACHE_KEY = "rss:timeline";
+const CACHE_TTL = 60 * 60 * 3; // 3時間（ミリ秒）
 
-// 年月単位でネストされたデータ構造に変換
-const rss = groupItems(feedItemList);
+type CachedData = {
+	data: GroupedPerYear[];
+	socials: SocialIcon[];
+	cachedAt: number;
+};
+
+const startTime = performance.now();
+
+// キャッシュから取得（必ず存在する前提）
+const cached = await redis.get<CachedData>(CACHE_KEY);
+
+if (!cached) {
+	throw new Error("キャッシュが存在しません");
+}
+
+const { data: rss, socials, cachedAt } = cached;
+const age = Date.now() - cachedAt;
+
+console.log(`[キャッシュ使用] ${(age / 1000).toFixed(0)}秒前のデータ`);
+console.log(`[合計処理時間] ${(performance.now() - startTime).toFixed(2)}ms`);
+
+// 3時間以上経過していたらバックグラウンドで更新（awaitしない）
+if (age > CACHE_TTL * 1000) {
+	console.log("[バックグラウンド更新開始]");
+
+	Promise.all([getAboutContent(), getTopMenuImages()])
+		.then(([about, { socials: newSocials }]) =>
+			getRssTimeline(about.rss).then((feedItemList) => ({
+				feedItemList,
+				socials: newSocials,
+			})),
+		)
+		.then(({ feedItemList, socials: newSocials }) => {
+			const newRss = groupItems(feedItemList);
+			return redis.set(CACHE_KEY, {
+				data: newRss,
+				socials: newSocials,
+				cachedAt: Date.now(),
+			});
+		})
+		.then(() => console.log("[バックグラウンド更新完了]"))
+		.catch((err) => console.error("[バックグラウンド更新エラー]", err));
+}
 ---
 
 <div class="secondIn opacity-0">

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
 	readonly API_SERVICE_DOMAIN: string;
 	readonly API_KEY: string;
 	readonly VERCEL_URL: string;
+	readonly UPSTASH_REDIS_REST_URL: string;
+	readonly UPSTASH_REDIS_REST_TOKEN: string;
 }
 
 interface ImportMeta {

--- a/src/lib/kv-client/index.ts
+++ b/src/lib/kv-client/index.ts
@@ -1,0 +1,6 @@
+import { Redis } from "@upstash/redis";
+
+export const redis = new Redis({
+	url: import.meta.env.UPSTASH_REDIS_REST_URL,
+	token: import.meta.env.UPSTASH_REDIS_REST_TOKEN,
+});

--- a/src/pages/experiences.astro
+++ b/src/pages/experiences.astro
@@ -5,6 +5,9 @@ import Meta from "../components/Layouts/Meta";
 import Header from "../components/Layouts/Header";
 import Footer from "../components/Layouts/Footer";
 import ExperienceContainer from "../components/Routes/Experiences/Container/index.astro";
+import { getAboutContent, getTopMenuImages } from "../lib/cms-client";
+import { getRssTimeline, groupItems } from "../lib/rss-reader";
+import { redis } from "../lib/kv-client";
 import type { SiteOg } from "../components/Layouts/Meta";
 
 const og: SiteOg = {
@@ -12,13 +15,31 @@ const og: SiteOg = {
 	type: "article",
 	url: "experiences",
 };
+
+const CACHE_KEY = "rss:timeline";
+
+const [about, { socials }] = await Promise.all([
+	getAboutContent(),
+	getTopMenuImages(),
+]);
+
+const feedItemList = await getRssTimeline(about.rss);
+const rss = groupItems(feedItemList);
+
+await redis.set(CACHE_KEY, {
+	data: rss,
+	socials,
+	cachedAt: Date.now(),
+});
+
+console.log(`[ビルド時キャッシュ作成] ${new Date().toISOString()}`);
 ---
 
 <Meta title={"Experiences"} og={og}>
 	<Header title="Experiences" />
 	<main class="secondIn">
 		<ExperienceContainer server:defer>
-			<div slot="fallback" class="min-h-[100dvh]" />
+			<div slot="fallback" class="min-h-[100dvh]"></div>
 		</ExperienceContainer>
 		<Footer />
 	</main>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -9,7 +9,7 @@ export async function GET(context: APIContext) {
 	return rss({
 		title: CONSTS.SITE_NAME,
 		description: CONSTS.SITE_DESCRIPTION,
-		site: context.site?.origin ?? CONSTS.SITE_DOMAIN,
+		site: context.site?.origin || CONSTS.SITE_DOMAIN,
 		items: blogs.map((blog) => ({
 			title: blog.title,
 			description: blog.summary,


### PR DESCRIPTION
## 概要
ExperienceのRSSタイムラインの初期表示を高速化。
自サイトのrss.xmlがミスっててタイムラインからブログ記事へ遷移できない問題に対応。

## 変更点

### Before
- サーバーアイランドでその都度タイムラインを生成。（初期表示のみ遅い、次回からキャッシュ）

### After
- ビルド時、タイムライン用のJSONをUpstashへキャッシュ。
- サーバーアイランドはUpstashからキャッシュしたデータをフェッチ。
- キャッシュのタイムスタンプが3時間より前かどうかをチェック。
- バックグラウンドで再生成・キャッシュを更新。

## 備考
タイムラインから`/blog/[blogId]`へ遷移できない問題があった。
ポートフォリオサイトのRSS生成に問題があり、リンクのドメイン部分が`undefined`になっていた。
（例：`https://undefined/blog/xh3anjzwgy/`）

`src/pages/rss.xml.ts`を修正し、実行する環境ごとのドメイン（ローカルなら`localhost`）が反映されるようにした。