### PR TITLE
RSSのXMLが正しく生成されるように修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ import { CONSTS } from "./consts";
 export default defineConfig({
 	integrations: [tailwind(), react(), sitemap()],
 
-	site: CONSTS.SITE_DOMAIN,
+	site: CONSTS.PRD_SITE_DOMAIN,
 
 	adapter: vercel(),
 

--- a/consts.ts
+++ b/consts.ts
@@ -1,7 +1,8 @@
 export const CONSTS = {
 	SITE_NAME: "PORTFOLIO",
 	SITE_DOMAIN: import.meta.env.DEV
-		? "http://localhost:4321/"
+		? "http://localhost:4321"
 		: `https://${import.meta.env.VERCEL_URL}`,
 	SITE_DESCRIPTION: "Personal website of oonawa",
+	PRD_SITE_DOMAIN: "https://oonawa-portfolio.vercel.app",
 } as const;

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -9,11 +9,11 @@ export async function GET(context: APIContext) {
 	return rss({
 		title: CONSTS.SITE_NAME,
 		description: CONSTS.SITE_DESCRIPTION,
-		site: context.site?.origin || CONSTS.SITE_DOMAIN,
+		site: context.site || CONSTS.PRD_SITE_DOMAIN,
 		items: blogs.map((blog) => ({
 			title: blog.title,
 			description: blog.summary,
-			link: `/blog/${blog.id}`,
+			link: `/blogs/${blog.id}`,
 			pubDate: new Date(blog.createdAt),
 		})),
 	});


### PR DESCRIPTION
## 概要
RSSのXMLが正しく生成されるように修正

## 変更点

- `/blog/[blogId]`→`/blogs/[blogId]`
- `astro.config.mjs`の`site`へ本番ドメインを指定
- `rss.xml.ts`の`context.site`のフォールバックにも本番ドメインを指定