### PR TITLE
READMEを修正・Makeコマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+install:
+	pnpm install
+
+dev:
+	pnpm run dev
+
+build:
+	pnpm run build

--- a/README.md
+++ b/README.md
@@ -1,47 +1,16 @@
-# Astro Starter Kit: Minimal
+<h1 align="center">My Portfolio Site</h1>
 
-```sh
-npm create astro@latest -- --template minimal
-```
+<p align="center">
+  <strong>
+    <a href="https://oonawa-portfolio.vercel.app/" target="_blank" rel="noopener noreferrer">
+        <img src="https://images.microcms-assets.io/assets/286786326ac4469587af976e633a89ad/1792b737edc44c378323db55aa2b9fc5/2026-01-30%2011.53%E3%81%AE%E7%94%BB%E5%83%8F.png" alt="">
+    </a>
+  </strong>
+</p>
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
+## Notes
+- Astro・React・TailwindCSSをつかっています。
+- CMSにはmicroCMSを使用しています。
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+デザインについての詳細はこちら
+https://oonawa-portfolio.vercel.app/blogs/xh3anjzwgy


### PR DESCRIPTION
## 概要

- README.mdをAstroのデフォルトから変更。
- Makefileを追加。


## 備考

本当は開発者向けの記載を追加するためにMakeコマンドを入れたけど、シークレットが用意できないとほとんどプレビューできないので中断した。 

microCMS側のセットアップ手順も併せてドキュメント化が必要かもしれない。